### PR TITLE
экран SignUp, сепаратор и маленькие изменения в других моих экранах

### DIFF
--- a/Scenes/Sources/LaunchScreen/LaunchScreenView.swift
+++ b/Scenes/Sources/LaunchScreen/LaunchScreenView.swift
@@ -68,7 +68,7 @@ final class LaunchScreenView: View {
     override func setupLayout() {
         super.setupLayout()
 
-        stackView.topAnchor ~= safeAreaLayoutGuide.topAnchor + 310
+        stackView.topAnchor ~= centerYAnchor - 52
         stackView.leftAnchor ~= leftAnchor + 52
         stackView.rightAnchor ~= rightAnchor - 52
     }

--- a/Scenes/Sources/SignUp/SignUpBuilder.swift
+++ b/Scenes/Sources/SignUp/SignUpBuilder.swift
@@ -1,0 +1,27 @@
+//
+//  SignUpBuilder.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import UIKit
+
+final class SignUpBuilder {
+    static func build() -> UIViewController {
+        let viewController = SignUpViewController()
+        let presenter = SignUpPresenter(view: viewController)
+        let interactor = SignUpInteractor(
+            presenter: presenter,
+            worker: SignUpWorker()
+        )
+        let router = SignUpRouter(
+            viewController: viewController,
+            dataStore: interactor
+        )
+        viewController.interactor = interactor
+        viewController.router = router
+        return viewController
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpInteractor.swift
+++ b/Scenes/Sources/SignUp/SignUpInteractor.swift
@@ -1,0 +1,51 @@
+//
+//  SignUpInteractor.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import Foundation
+
+final class SignUpInteractor {
+    private let presenter: SignUpPresentationLogic
+    private let worker: SignUpWorkingLogic
+
+    init(presenter: SignUpPresentationLogic, worker: SignUpWorkingLogic) {
+        self.presenter = presenter
+        self.worker = worker
+    }
+}
+
+extension SignUpInteractor: SignUpBusinessLogic {
+    func request(_ request: SignUp.Fetch.Request) {
+        presenter.present(SignUp.Fetch.Response())
+    }
+    
+    func request(_ request: SignUp.ContinueWithApple.Request) {
+        presenter.present(SignUp.ContinueWithApple.Response())
+    }
+    
+    func request(_ request: SignUp.ContinueWithGoogle.Request) {
+        presenter.present(SignUp.ContinueWithGoogle.Response())
+    }
+    
+    func request(_ request: SignUp.CreateAccount.Request) {
+        presenter.present(SignUp.CreateAccount.Response())
+    }
+    
+    func request(_ request: SignUp.TermsOfUse.Request) {
+        presenter.present(SignUp.TermsOfUse.Response())
+    }
+    
+    func request(_ request: SignUp.PrivacyPolicy.Request) {
+        presenter.present(SignUp.PrivacyPolicy.Response())
+    }
+    
+    func request(_ request: SignUp.EnterAccount.Request) {
+        presenter.present(SignUp.EnterAccount.Response())
+    }
+}
+
+extension SignUpInteractor: SignUpDataStore {}

--- a/Scenes/Sources/SignUp/SignUpModels.swift
+++ b/Scenes/Sources/SignUp/SignUpModels.swift
@@ -1,0 +1,67 @@
+//
+//  SignUpModels.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import Foundation
+
+enum SignUp {
+    enum Fetch {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum ContinueWithApple {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum ContinueWithGoogle {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum CreateAccount {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum TermsOfUse {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum PrivacyPolicy {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+    
+    enum EnterAccount {
+        struct Request {}
+
+        struct Response {}
+
+        struct ViewModel {}
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpPresenter.swift
+++ b/Scenes/Sources/SignUp/SignUpPresenter.swift
@@ -1,0 +1,45 @@
+//
+//  SignUpPresenter.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+final class SignUpPresenter {
+    weak var view: SignUpDisplayLogic?
+
+    init(view: SignUpDisplayLogic) {
+        self.view = view
+    }
+}
+
+extension SignUpPresenter: SignUpPresentationLogic {
+    func present(_ response: SignUp.Fetch.Response) {
+        view?.display(SignUp.Fetch.ViewModel())
+    }
+    
+    func present(_ response: SignUp.ContinueWithApple.Response) {
+        view?.display(SignUp.ContinueWithApple.ViewModel())
+    }
+    
+    func present(_ response: SignUp.ContinueWithGoogle.Response) {
+        view?.display(SignUp.ContinueWithGoogle.ViewModel())
+    }
+    
+    func present(_ response: SignUp.CreateAccount.Response) {
+        view?.display(SignUp.CreateAccount.ViewModel())
+    }
+    
+    func present(_ response: SignUp.TermsOfUse.Response) {
+        view?.display(SignUp.TermsOfUse.ViewModel())
+    }
+    
+    func present(_ response: SignUp.PrivacyPolicy.Response) {
+        view?.display(SignUp.PrivacyPolicy.ViewModel())
+    }
+    
+    func present(_ response: SignUp.EnterAccount.Response) {
+        view?.display(SignUp.EnterAccount.ViewModel())
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpProtocols.swift
+++ b/Scenes/Sources/SignUp/SignUpProtocols.swift
@@ -1,0 +1,52 @@
+//
+//  SignUpProtocols.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import Foundation
+
+protocol SignUpBusinessLogic: AnyObject {
+    func request(_ request: SignUp.Fetch.Request)
+    func request(_ request: SignUp.ContinueWithApple.Request)
+    func request(_ request: SignUp.ContinueWithGoogle.Request)
+    func request(_ request: SignUp.CreateAccount.Request)
+    func request(_ request: SignUp.TermsOfUse.Request)
+    func request(_ request: SignUp.PrivacyPolicy.Request)
+    func request(_ request: SignUp.EnterAccount.Request)
+}
+
+protocol SignUpPresentationLogic: AnyObject {
+    func present(_ response: SignUp.Fetch.Response)
+    func present(_ response: SignUp.ContinueWithApple.Response)
+    func present(_ response: SignUp.ContinueWithGoogle.Response)
+    func present(_ response: SignUp.CreateAccount.Response)
+    func present(_ response: SignUp.TermsOfUse.Response)
+    func present(_ response: SignUp.PrivacyPolicy.Response)
+    func present(_ response: SignUp.EnterAccount.Response)
+}
+
+protocol SignUpDisplayLogic: AnyObject {
+    func display(_ viewModel: SignUp.Fetch.ViewModel)
+    func display(_ viewModel: SignUp.ContinueWithApple.ViewModel)
+    func display(_ viewModel: SignUp.ContinueWithGoogle.ViewModel)
+    func display(_ viewModel: SignUp.CreateAccount.ViewModel)
+    func display(_ viewModel: SignUp.TermsOfUse.ViewModel)
+    func display(_ viewModel: SignUp.PrivacyPolicy.ViewModel)
+    func display(_ viewModel: SignUp.EnterAccount.ViewModel)
+}
+
+protocol SignUpRoutingLogic: AnyObject {
+    func continueWithApple()
+    func continueWithGoogle()
+    func createAccount()
+    func termsOfUse()
+    func privacyPolicy()
+    func enterAccount()
+}
+
+protocol SignUpDataStore: AnyObject {}
+
+protocol SignUpWorkingLogic: AnyObject {}

--- a/Scenes/Sources/SignUp/SignUpRouter.swift
+++ b/Scenes/Sources/SignUp/SignUpRouter.swift
@@ -1,0 +1,45 @@
+//
+//  SignUpRouter.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import UIKit
+
+final class SignUpRouter {
+    weak var viewController: SignUpViewController?
+    var dataStore: SignUpDataStore?
+
+    init(viewController: SignUpViewController, dataStore: SignUpDataStore) {
+        self.viewController = viewController
+        self.dataStore = dataStore
+    }
+}
+
+extension SignUpRouter: SignUpRoutingLogic {
+    func continueWithApple() {
+        
+    }
+    
+    func continueWithGoogle() {
+        
+    }
+    
+    func createAccount() {
+        
+    }
+    
+    func termsOfUse() {
+        
+    }
+    
+    func privacyPolicy() {
+        
+    }
+    
+    func enterAccount() {
+        
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpView.swift
+++ b/Scenes/Sources/SignUp/SignUpView.swift
@@ -1,0 +1,259 @@
+//
+//  SignUpView.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import UIKit
+import UIComponents
+
+final class SignUpView: View {
+    
+    enum Action {
+        case continueWithApple
+        case continueWithGoogle
+        case createAccount
+        case termsOfUse
+        case privacyPolicy
+        case enterAccount
+    }
+    
+    var actionHandler: (Action) -> Void = { _ in }
+    
+    private let image: UIImageView = {
+        let view = UIImageView()
+        view.image = Image(named: "SignUp")
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+    
+    private let titleLabel: Label = {
+        let view = Label(size: 28, font: .ceraBold)
+        view.textColor = .textFirst
+        let text = "Зарегистрируйcя,\nчтобы продолжить"
+        let attributedText = NSMutableAttributedString(string: text)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 8
+        paragraphStyle.alignment = .center
+        attributedText.addAttribute(
+            .paragraphStyle,
+            value: paragraphStyle,
+            range: NSRange(location: 0, length: text.count)
+        )
+        view.attributedText = attributedText
+        view.heightAnchor ~= 71
+        return view
+    }()
+    
+    private lazy var appleButton: Button = {
+        let view = Button(
+            text: "Продолжить с Apple",
+            style: .secondary,
+            size: .large,
+            icon: .apple,
+            iconSpacing: 8
+        )
+        view.textColor = .textFirst
+        view.textFont = .sfSemibold
+        view.textSize = 17
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.actionHandler = {
+            self.actionHandler(.continueWithApple)
+        }
+        return view
+    }()
+    
+    private lazy var googleButton: Button = {
+        let view = Button(
+            text: "Продолжить с Google",
+            style: .secondary,
+            size: .large,
+            icon: .google,
+            iconSpacing: 8
+        )
+        view.textColor = .textFirst
+        view.textFont = .sfSemibold
+        view.textSize = 17
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.actionHandler = {
+            self.actionHandler(.continueWithGoogle)
+        }
+        return view
+    }()
+    
+    private let separatorView: SeparatorOrView = {
+        let view = SeparatorOrView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var createAccauntButton: Button = {
+        let view = Button(
+            text: "Создать аккаунт",
+            style: .primary,
+            size: .large
+        )
+        view.textFont = .sfSemibold
+        view.textSize = 17
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.actionHandler = {
+            self.actionHandler(.createAccount)
+        }
+        return view
+    }()
+    
+    private lazy var conditionsLabel: Label = {
+        let view = Label(size: 12, font: .ptRootRegular)
+        view.textColor = .textFirst
+        let textPart1 = "Создавая аккаунт, ты  соглашаешься с "
+        let textPart2 = "Условиями использования"
+        let textPart3 = " и "
+        let textPart4 = "Политикой конфиденциальности"
+        let text = textPart1 + textPart2 + textPart3 + textPart4
+        let attributedText = NSMutableAttributedString(string: text)
+        let color = UIColor.buttonActive
+        guard let color = color else { return view }
+        attributedText.addAttribute(
+            .foregroundColor,
+            value: color,
+            range: NSRange(
+                location: textPart1.count,
+                length: textPart2.count
+            )
+        )
+        attributedText.addAttribute(
+            .foregroundColor,
+            value: color,
+            range: NSRange(
+                location: textPart1.count + textPart2.count + textPart3.count,
+                length: textPart4.count
+            )
+        )
+        view.attributedText = attributedText
+        view.isUserInteractionEnabled = true
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTapOnLabel(_:)))
+        view.addGestureRecognizer(tapGestureRecognizer)
+        return view
+    }()
+    
+    @objc private func handleTapOnLabel(_ recognizer: UITapGestureRecognizer) {
+        let location = recognizer.location(in: conditionsLabel)
+        let text = (conditionsLabel.attributedText?.string)!
+        let textStorage = NSTextStorage(attributedString: conditionsLabel.attributedText!)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            size: CGSize(
+                width: conditionsLabel.frame.size.width,
+                height: conditionsLabel.frame.size.height
+            )
+        )
+        layoutManager.addTextContainer(textContainer)
+
+        var linkRange = NSRange(location: 0, length: 0)
+        let index = layoutManager.characterIndex(
+            for: location,
+            in: textContainer,
+            fractionOfDistanceBetweenInsertionPoints: nil
+        )
+        if let attributes = conditionsLabel.attributedText?.attributes(
+            at: index,
+            effectiveRange: &linkRange
+        ) {
+            let color = attributes[NSAttributedString.Key.foregroundColor] as? UIColor
+            if color == .buttonActive {
+                let textPart2 = "Условиями использования"
+                let textPart4 = "Политикой конфиденциальности"
+                if (text as NSString).substring(with: linkRange) == textPart2 {
+                    print("1")
+                } else if (text as NSString).substring(with: linkRange) == textPart4 {
+                    print("2")
+                }
+            }
+        }
+    }
+    
+    private let scrollView: UIScrollView = {
+        let view = UIScrollView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alwaysBounceVertical = true
+        view.showsVerticalScrollIndicator = false
+        return view
+    }()
+    
+    private let accountLabel: Label = {
+        let view = Label(size: 16, font: .ptRootRegular)
+        view.viewModel = .init(text: "Уже есть аккаунт?", textAlignment: .left, textColor: .textFirst)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.required, for: .horizontal)
+        view.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return view
+    }()
+    
+    private lazy var enterButton: Button = {
+        let view = Button(text: "Войти")
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.actionHandler = {
+            self.actionHandler(.enterAccount)
+        }
+        return view
+    }()
+    
+    private lazy var horizontalStackView: UIStackView = {
+        let view = UIStackView(arrangedSubviews: [
+            accountLabel,
+            enterButton
+        ])
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .horizontal
+        view.spacing = 8
+        return view
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let view = UIStackView(arrangedSubviews: [
+            image,
+            titleLabel,
+            appleButton,
+            googleButton,
+            separatorView,
+            createAccauntButton,
+            conditionsLabel,
+            horizontalStackView
+        ])
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.axis = .vertical
+        view.setCustomSpacing(0, after: image)
+        view.setCustomSpacing(32, after: titleLabel)
+        view.setCustomSpacing(24, after: conditionsLabel)
+        view.spacing = 16
+        return view
+    }()
+    
+    override func setupContent() {
+        super.setupContent()
+        
+        backgroundColor = .backgroundGeneral
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+    }
+
+    override func setupLayout() {
+        super.setupLayout()
+        
+        scrollView.topAnchor ~= safeAreaLayoutGuide.topAnchor
+        scrollView.leftAnchor ~= leftAnchor
+        scrollView.rightAnchor ~= rightAnchor
+        scrollView.bottomAnchor ~= safeAreaLayoutGuide.bottomAnchor
+        
+        stackView.widthAnchor ~= scrollView.frameLayoutGuide.widthAnchor - 32
+        stackView.topAnchor ~= scrollView.topAnchor + 110
+        stackView.leftAnchor ~= scrollView.leftAnchor + 16
+        stackView.rightAnchor ~= scrollView.rightAnchor - 16
+        stackView.bottomAnchor <= scrollView.bottomAnchor - 16
+        let bottom = stackView.bottomAnchor ~= scrollView.bottomAnchor
+        bottom.priority = .defaultHigh
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpViewController.swift
+++ b/Scenes/Sources/SignUp/SignUpViewController.swift
@@ -1,0 +1,73 @@
+//
+//  SignUpViewController.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import UIKit
+
+final class SignUpViewController: UIViewController {
+    var interactor: SignUpBusinessLogic?
+    var router: SignUpRoutingLogic?
+
+    private lazy var rootView = SignUpView()
+
+    override func loadView() {
+        super.loadView()
+        view = rootView
+        
+        rootView.actionHandler = { action in
+            switch action {
+            case .continueWithApple:
+                self.interactor?.request(SignUp.ContinueWithApple.Request())
+            case .continueWithGoogle:
+                self.interactor?.request(SignUp.ContinueWithGoogle.Request())
+            case .createAccount:
+                self.interactor?.request(SignUp.CreateAccount.Request())
+            case .termsOfUse:
+                self.interactor?.request(SignUp.TermsOfUse.Request())
+            case .privacyPolicy:
+                self.interactor?.request(SignUp.PrivacyPolicy.Request())
+            case .enterAccount:
+                self.interactor?.request(SignUp.EnterAccount.Request())
+            }
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.interactor?.request(SignUp.Fetch.Request())
+    }
+}
+
+extension SignUpViewController: SignUpDisplayLogic {
+    func display(_ viewModel: SignUp.Fetch.ViewModel) {
+        
+    }
+    
+    func display(_ viewModel: SignUp.ContinueWithApple.ViewModel) {
+        router?.continueWithApple()
+    }
+    
+    func display(_ viewModel: SignUp.ContinueWithGoogle.ViewModel) {
+        router?.continueWithGoogle()
+    }
+    
+    func display(_ viewModel: SignUp.CreateAccount.ViewModel) {
+        router?.createAccount()
+    }
+    
+    func display(_ viewModel: SignUp.TermsOfUse.ViewModel) {
+        router?.termsOfUse()
+    }
+    
+    func display(_ viewModel: SignUp.PrivacyPolicy.ViewModel) {
+        router?.privacyPolicy()
+    }
+    
+    func display(_ viewModel: SignUp.EnterAccount.ViewModel) {
+        router?.enterAccount()
+    }
+}

--- a/Scenes/Sources/SignUp/SignUpWorker.swift
+++ b/Scenes/Sources/SignUp/SignUpWorker.swift
@@ -1,0 +1,11 @@
+//
+//  SignUpWorker.swift
+//  E-book
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//  Copyright (c) 2023. All rights reserved.
+//
+
+import Foundation
+
+final class SignUpWorker: SignUpWorkingLogic {}

--- a/Scenes/Sources/Welcome/WelcomeRouter.swift
+++ b/Scenes/Sources/Welcome/WelcomeRouter.swift
@@ -20,7 +20,7 @@ final class WelcomeRouter {
 
 extension WelcomeRouter: WelcomeRoutingLogic {
     func registration() {
-
+        viewController?.navigationController?.pushViewController(SignUpBuilder.build(), animated: true)
     }
     
     func login() {

--- a/UIComponents/Sources/Buttons/Button.swift
+++ b/UIComponents/Sources/Buttons/Button.swift
@@ -28,6 +28,7 @@ public class Button: UIControl {
     public var textColor: UIColor? {
         didSet {
             title.textColor = textColor
+            image.tintColor = textColor
         }
     }
     

--- a/UIComponents/Sources/Views/SeparatorOrView.swift
+++ b/UIComponents/Sources/Views/SeparatorOrView.swift
@@ -1,0 +1,61 @@
+//
+//  SeparatorOrView.swift
+//  
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//
+
+import UIKit
+
+public class SeparatorOrView: View {
+    
+    private let separatorLeft: SeparatorView = {
+        let view = SeparatorView(heigth: 2)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.cornerRadius = 1
+        return view
+    }()
+    
+    private let label: Label = {
+        let view = Label(size: 16, font: .ptRootRegular)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.viewModel = .init(
+            text: "или",
+            textAlignment: .center,
+            textColor: .textSecond
+        )
+        return view
+    }()
+
+    private let separatorRight: SeparatorView = {
+        let view = SeparatorView(heigth: 2)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.cornerRadius = 1
+        return view
+    }()
+    
+    public override func setupContent() {
+        super.setupContent()
+        
+        addSubview(separatorLeft)
+        addSubview(label)
+        addSubview(separatorRight)
+    }
+    
+    public override func setupLayout() {
+        super.setupLayout()
+        
+        separatorLeft.centerYAnchor ~= label.centerYAnchor
+        separatorLeft.leftAnchor ~= leftAnchor
+        separatorLeft.rightAnchor ~= label.leftAnchor
+        
+        label.widthAnchor ~= 95
+        label.topAnchor ~= topAnchor
+        label.bottomAnchor ~= bottomAnchor
+        label.centerXAnchor ~= centerXAnchor
+        
+        separatorRight.centerYAnchor ~= label.centerYAnchor
+        separatorRight.leftAnchor ~= label.rightAnchor
+        separatorRight.rightAnchor ~= rightAnchor
+    }
+}

--- a/UIComponents/Sources/Views/SeparatorView.swift
+++ b/UIComponents/Sources/Views/SeparatorView.swift
@@ -1,0 +1,50 @@
+//
+//  SeparatorView.swift
+//  
+//
+//  Created by Oleg Prygunov on 27.03.2023.
+//
+
+import UIKit
+
+public class SeparatorView: View {
+    
+    public var color: UIColor? {
+        didSet {
+            backgroundColor = color
+        }
+    }
+    
+    public var cornerRadius: CGFloat? {
+        didSet {
+            layer.cornerRadius = cornerRadius ?? 0
+        }
+    }
+    
+    
+    public init(heigth: CGFloat) {
+        super.init(frame: .zero)
+        heightAnchor.constraint(equalToConstant: heigth).isActive = true
+        
+    }
+    
+    public init(width: CGFloat) {
+        super.init(frame: .zero)
+        widthAnchor.constraint(equalToConstant: width).isActive = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func setupContent() {
+        super.setupContent()
+        backgroundColor = .separator
+    }
+    
+    public override func setupLayout() {
+        super.setupLayout()
+        
+    }
+}


### PR DESCRIPTION
Два сепаратора. Один просто как одна вертикальная или горизонтальная линия. Другой сепаратор с словом "или" по середине.

В кнопке добавил перекрашивание иконки вместе с текстом. Нужно на экране SignUp,  там другие цвета и шрифт у текста кнопки.

В LaunchScreenView была привязка к верху, перевязал на середину чтобы на iPhone SE  смотрелось тоже нормально.

На экране SignUp handleTapOnLabel и создание ссылок в тексте это решение из нескольких вариантов предложенных чатом жпт. Пробовал по разному, и добавлять атрибуты .link для ссылок, но тогда они становятся синими, и не перекрашиваются. Оставил атрибут .foregroundColor 